### PR TITLE
Add Travis continuous integration and build badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: generic
+dist: bionic
+
+install:
+  - sudo apt update
+  - cd source_code && make && cd ../
+
+script:
+  - ./PureseqTM.sh -i example/4j7cK.fasta -m 0
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # PureseqTM
+
+[![Build Status](https://travis-ci.org/richelbilderbeek/PureseqTM_Package.svg?branch=master)](https://travis-ci.org/richelbilderbeek/PureseqTM_Package)
+
 TransMembrane (TM) topology prediction from amino acid sequence only
 
 <p align="center">


### PR DESCRIPTION
Dear PureseqTM dev,

Two days ago, I [posted an Issue](https://github.com/PureseqTM/PureseqTM_Package/issues/2) in which I suggested to add a continuous integration service, as well as a build badge. I enjoy that the projects I love have CI, so I volunteered.

'Sadly', I could not restrain myself and already added it on my Fork. With this Pull Request, I suggest to add it to the main code base. I will even volunteer to main the `.travis.yml` file.

Upon acceptance, two things do need to be done, that I cannot do:

 * Travis CI needs to be activated for this repo: go to `travis-ci.org`, log in with GitHub, and activate
 * The build badge (in README) needs to have `richelbilderbeek` replaced by `PureseqTM`

I hope you enjoy me adding such a proof of quality! If no, sure, I'll accept :+1:


